### PR TITLE
Convertersのフォルダ構造の再編

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ factorio_factory/
 │   |   │   ├── base.py             # 変換のベースクラス
 │   |   │   ├── enum/               # JSONからEnumへの変換
 │   |   │   │   └── item_groups.py  
-│   |   │   └── json/               # EnumからJSONへの変換
+│   |   │   └── json/               # LuaからJSONへの変換
 │   |   │       └── item_groups.py
 │   |   ├── enum/                   # 識別子定義
 │   |   │   ├── item_group.py       # アイテムグループの列挙型

--- a/README.md
+++ b/README.md
@@ -23,8 +23,13 @@ factorio_factory/
 │   ├── loader/                     # 識別子生成
 │   |   ├── converters/             # 個別の変換ロジック
 │   |   │   ├── base.py             # 変換のベースクラス
-│   |   │   ├── item_groups_enum.py # アイテムグループのJsonへの変換
-│   |   │   └── item_groups_json.py # アイテムグループのEnumへの変換
+│   |   │   ├── enum/               # JSONからEnumへの変換
+│   |   │   │   └── item_groups.py  
+│   |   │   └── json/               # EnumからJSONへの変換
+│   |   │       └── item_groups.py
+│   |   ├── enum/                   # 識別子定義
+│   |   │   ├── item_group.py       # アイテムグループの列挙型
+│   |   │   └── item_subgroup.py
 │   |   ├── __init__.py             # パッケージ初期化
 │   |   ├── __main__.py             # コマンドライン実行用
 │   |   ├── config.py

--- a/core/loader/converters/enum/item_groups.py
+++ b/core/loader/converters/enum/item_groups.py
@@ -2,7 +2,7 @@ from core.loader.converters.base import BaseConverter  # 共通ユーティリ�
 from core.loader.registry import register
 
 
-@register("item_group_enum")
+@register("enum:item_group")
 class ItemGroupEnumConverter(BaseConverter):
     """
     アイテムグループに関するJSON -> Enum クラスの生成.

--- a/core/loader/converters/json/item_groups.py
+++ b/core/loader/converters/json/item_groups.py
@@ -3,7 +3,7 @@ from core.loader.registry import register
 from core.utils.lua_parser import parse_lua
 
 
-@register("item_group_json")
+@register("json:item_group")
 class ItemGroupJsonConverter(BaseConverter):
     """
     アイテムグループに関するLua -> JSONファイルの変換.

--- a/core/loader/registry.py
+++ b/core/loader/registry.py
@@ -26,14 +26,24 @@ def register(name: str):
 # -- 次に, 動的インポートの処理 --
 
 # converters パッケージのディレクトリを動的に読み取る
-module_name = "core.loader.converters"
-package = importlib.import_module(module_name)
+json_module_name = "core.loader.converters.json"
+package = importlib.import_module(json_module_name)
 package_path = pathlib.Path(package.__path__[0])
 
 # *.py モジュールをひとつずつインポート
 for file in package_path.iterdir():
     if file.suffix == ".py" and file.name != "__init__.py":
-        module_name = f"core.loader.converters.{file.stem}"
+        module_name = f"core.loader.converters.json.{file.stem}"
+        importlib.import_module(module_name)
+
+# enum モジュールも同様にインポート
+enum_module_name = "core.loader.converters.enum"
+package = importlib.import_module(enum_module_name)
+package_path = pathlib.Path(package.__path__[0])
+# *.py モジュールをひとつずつインポート
+for file in package_path.iterdir():
+    if file.suffix == ".py" and file.name != "__init__.py":
+        module_name = f"core.loader.converters.enum.{file.stem}"
         importlib.import_module(module_name)
 
 # ここまでで、converters/ 内の各モジュールが一度インポートされ、
@@ -50,11 +60,11 @@ def load_all():
     """
 
     for name, conv in CONVERTERS.items():
-        if name.endswith("_json"):
+        if name.startswith("json:"):
             print(f"[registry] Running JSON converter: {name}")
             conv.load()
 
     for name, conv in CONVERTERS.items():
-        if name.endswith("_enum"):
+        if name.startswith("enum:"):
             print(f"[registry] Running Enum converter: {name}")
             conv.load()

--- a/core/loader/registry.py
+++ b/core/loader/registry.py
@@ -25,26 +25,29 @@ def register(name: str):
 
 # -- 次に, 動的インポートの処理 --
 
-# converters パッケージのディレクトリを動的に読み取る
-json_module_name = "core.loader.converters.json"
-package = importlib.import_module(json_module_name)
-package_path = pathlib.Path(package.__path__[0])
 
-# *.py モジュールをひとつずつインポート
-for file in package_path.iterdir():
-    if file.suffix == ".py" and file.name != "__init__.py":
-        module_name = f"core.loader.converters.json.{file.stem}"
-        importlib.import_module(module_name)
+def dynamic_import_one_by_one(module_name: str):
+    """
+    指定されたモジュール以下のモジュールを動的にインポートする。
+    モジュール名は 'core.loader.converters.json' のような形式で指定。
+    """
+    package = importlib.import_module(module_name)
+    package_path = pathlib.Path(package.__path__[0])
 
-# enum モジュールも同様にインポート
-enum_module_name = "core.loader.converters.enum"
-package = importlib.import_module(enum_module_name)
-package_path = pathlib.Path(package.__path__[0])
-# *.py モジュールをひとつずつインポート
-for file in package_path.iterdir():
-    if file.suffix == ".py" and file.name != "__init__.py":
-        module_name = f"core.loader.converters.enum.{file.stem}"
-        importlib.import_module(module_name)
+    # *.py モジュールをひとつずつインポート
+    for file in package_path.iterdir():
+        if file.suffix == ".py" and file.name != "__init__.py":
+            module_name = f"{module_name}.{file.stem}"
+            importlib.import_module(module_name)
+
+
+# Lua -> JSON変換パッケージのディレクトリを動的に読み取る
+json_converters_module_name = "core.loader.converters.json"
+dynamic_import_one_by_one(json_converters_module_name)
+
+# Enum -> Python Enum クラス変換パッケージのディレクトリを動的に読み取る
+enum_converters_module_name = "core.loader.converters.enum"
+dynamic_import_one_by_one(enum_converters_module_name)
 
 # ここまでで、converters/ 内の各モジュールが一度インポートされ、
 # それぞれのクラス定義に付いた @register() が実行される。


### PR DESCRIPTION
* converters/を以下のように再編
```
core/loader/converters/
├── base.py
├── json/
│   ├── __init__.py
│   └── item_groups.py       # Lua → JSON 用
│   └── item_subgroups.py
├── enum/
│   ├── __init__.py
│   └── item_groups.py       # JSON → Enum 用
│   └── item_subgroups.py
...
```

* registryの読み込み方も対応させる
* registerのキーを修正(例: "item_group_enum" -> "enum:item_group")
* README.mdの修正