### PR TITLE
 CLI をフェーズ別に拡張

### DIFF
--- a/core/loader/registry.py
+++ b/core/loader/registry.py
@@ -26,6 +26,7 @@ def register(name: str):
 
     def _decorator(cls):
         instance = cls()
+        instance.name = name  # インスタンスに名前を設定
         CONVERTERS[name] = instance
         # そのクラスが持つ dependencies 属性を DEPS に保存
         # （もし dependencies が定義されていなければ空リストとみなす）


### PR DESCRIPTION
core/loader/__main__.py にフェーズごとのエントリを追加。
実行イメージ
```python
python -m core.loader build-json       # data/raw/ → data/intermediate/（JSON生成まで）
python -m core.loader build-enum       # data/intermediate/ → core/enum/（Enum生成まで）
python -m core.loader build-models     # data/intermediate/ → core/01_models/（Pydantic生成まで）
python -m core.loader clean            # 中間生成物の削除 etc.
```
ログレベルや出力パスのオプションを CLI 引数で受け取れるようにもする。

stage="json" なら、依存なしの JSON Converter だけ
stage="enum" なら JSON ConverterとEnum Converter を実行