### PR TITLE
Keep Factorio data filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ CLIツールを使ってwube/factorio-dataのプロトタイプ定義をEnum識�
 python -m core.loader build
 ```
 
+## テストの実行
+pytest を使ってユニットテストを実行できます。
+```bash
+pytest -q
+```
+
 ## 編集上の注意
 `core/enums/`以下のファイルで, manual_*.py以外のファイルは自動生成されるため, 手動で編集しないでください.
 * 編集NG: `item_group.py`           # アイテムグループの列挙型

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# Package for core modules

--- a/data/fetcher.sh
+++ b/data/fetcher.sh
@@ -48,7 +48,7 @@ fi
 
 for FILE in "${FILES[@]}"; do
   SRC="$CACHE_DIR/$FILE"
-  DST="$RAW_DIR/$(basename $FILE)"
+  DST="$RAW_DIR/$(basename "$FILE")"
   if [ -f "$SRC" ]; then
     if [ -f "$DST" ] && cmp -s "$SRC" "$DST"; then
       echo "Unchanged: $DST (skip)"

--- a/tests/fixtures/enum_expected_item_group.py
+++ b/tests/fixtures/enum_expected_item_group.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ItemGroup(Enum):
+    Group1 = 'group1'
+    Group2 = 'group2'
+    UnminedResource = 'unmined-resource'
+    Technology = 'technology'

--- a/tests/fixtures/enum_expected_item_subgroup.py
+++ b/tests/fixtures/enum_expected_item_subgroup.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ItemSubgroup(Enum):
+    Subgroup11 = 'subgroup1-1'
+    Subgroup12 = 'subgroup1-2'
+    Subgroup21 = 'subgroup2-1'
+    Subgroup22 = 'subgroup2-2'
+    UnminedResourceBasicSolid = 'unmined-resource-basic-solid'
+    UnminedResourceBasicFluid = 'unmined-resource-basic-fluid'
+    Technology = 'technology'

--- a/tests/test_converters_enum.py
+++ b/tests/test_converters_enum.py
@@ -1,0 +1,83 @@
+import os
+import shutil
+import importlib.util
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from core.loader.converters.enum.item_groups import ItemGroupEnumConverter
+
+
+@pytest.fixture
+def enum_converter(tmp_path):
+    intermediate = tmp_path / "intermediate"
+    enum_out = tmp_path / "enum"
+    intermediate.mkdir()
+    enum_out.mkdir()
+    fixtures_dir = os.path.join(os.path.dirname(__file__), "fixtures")
+
+    shutil.copyfile(
+        os.path.join(fixtures_dir, "json_sample_item_groups.json"),
+        intermediate / "item_groups.json",
+    )
+    shutil.copyfile(
+        os.path.join(fixtures_dir, "json_sample_item_subgroups.json"),
+        intermediate / "item_subgroups.json",
+    )
+
+    converter = ItemGroupEnumConverter()
+    converter.intermediate_dir = str(intermediate)
+    converter.enum_dir = str(enum_out)
+    return converter
+
+
+def _import_enum(path: str, class_name: str):
+    spec = importlib.util.spec_from_file_location(class_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(module)
+    return getattr(module, class_name)
+
+
+def test_item_groups_enum_generation(enum_converter):
+    converter = enum_converter
+
+    converter.load()
+
+    fixtures_dir = os.path.join(os.path.dirname(__file__), "fixtures")
+
+    item_group_path = os.path.join(converter.enum_dir, "item_group.py")
+    expected_item_group = os.path.join(fixtures_dir, "enum_expected_item_group.py")
+    assert os.path.isfile(item_group_path)
+    with open(item_group_path) as gen, open(expected_item_group) as exp:
+        assert gen.read() == exp.read()
+
+    ItemGroup = _import_enum(item_group_path, "ItemGroup")
+    assert {m.value for m in ItemGroup} == {
+        "group1",
+        "group2",
+        "unmined-resource",
+        "technology",
+    }
+
+    item_subgroup_path = os.path.join(converter.enum_dir, "item_subgroup.py")
+    expected_item_subgroup = os.path.join(fixtures_dir, "enum_expected_item_subgroup.py")
+    assert os.path.isfile(item_subgroup_path)
+    with open(item_subgroup_path) as gen, open(expected_item_subgroup) as exp:
+        assert gen.read() == exp.read()
+
+    ItemSubgroup = _import_enum(item_subgroup_path, "ItemSubgroup")
+    expected_subgroups = [
+        "subgroup1-1",
+        "subgroup1-2",
+        "subgroup2-1",
+        "subgroup2-2",
+        "unmined-resource-basic-solid",
+        "unmined-resource-basic-fluid",
+        "technology",
+    ]
+    subgroup_members = [m.value for m in ItemSubgroup]
+    assert set(subgroup_members) == set(expected_subgroups)
+    assert len(subgroup_members) == len(expected_subgroups)

--- a/tests/test_converters_json.py
+++ b/tests/test_converters_json.py
@@ -1,6 +1,11 @@
 import os
 import shutil
 import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 import pytest
 from core.loader.converters.json.item_groups import ItemGroupJsonConverter
 
@@ -21,8 +26,7 @@ def json_converter(tmp_path):
     # テスト用 Lua スニペットをコピーし、Converter が期待するファイル名にリネーム
     shutil.copyfile(
         os.path.join(fixtures_dir, "lua-sample-item-groups.lua"),
-        input_base
-        / "item-groups.lua",  # Converter が 'item-groups.lua' を読みに行く想定
+        input_base / "item-groups.lua",  # Converter が 'item-groups.lua' を読みに行く想定
     )
 
     converter = ItemGroupJsonConverter()


### PR DESCRIPTION
## Summary
- revert filename translation: keep `item-groups.lua`
- adjust JSON converter, fetcher script and tests accordingly

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f90536ab88329ab3ba0be5d6c5a61