### PR TITLE
Add converters for assembling machines and mining drills

### DIFF
--- a/core/loader/converters/model/allowed/mining_drill.py
+++ b/core/loader/converters/model/allowed/mining_drill.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from core.loader.converters.base import BaseConverter
+from core.loader.registry import register
+
+
+@register("allowed:mining_drill")
+class MiningDrillAllowedConverter(BaseConverter):
+    """Generate allowed set for MiningDrill enum."""
+
+    dependencies = ["json:mining_drill", "enum:assembling_machine"]
+    json_filename = "mining_drill.json"
+    allowed_filename = "mining_drill.py"
+
+    def load(self) -> None:
+        from core.enums.assembling_machine import AssemblingMachine
+
+        drills = self.load_json(f"{self.intermediate_dir}/{self.json_filename}")
+        ret = [AssemblingMachine(d["name"]) for d in drills]
+
+        out = [
+            "from core.enums.assembling_machine import AssemblingMachine",
+            "",
+            "mining_drill_allowed: set[AssemblingMachine] = {",
+            *[f"    {m}," for m in ret],
+            "}",
+        ]
+        (Path(self.allowed_dir) / self.allowed_filename).write_text("\n".join(out))

--- a/core/loader/converters/model/data/assembling_machine.py
+++ b/core/loader/converters/model/data/assembling_machine.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+from sympy import Integer, Rational, srepr
+
+from core.loader.converters.base import BaseConverter
+from core.loader.registry import register
+
+
+@register("data:assembling_machine")
+class AssemblingMachineDataConverter(BaseConverter):
+    """Convert assembling machine related JSON to data dictionaries."""
+
+    dependencies = ["json:entities", "json:mining_drill", "enum:assembling_machine"]
+    json_entities_filename = "entities.json"
+    json_mining_drill_filename = "mining_drill.json"
+    data_path = "assembling_machine.py"
+    json_filenames = ["entities.json", "mining_drill.json"]
+
+    def _parse_power_kw(self, value: str) -> int:
+        if value.endswith("kW"):
+            return int(float(value[:-2]))
+        if value.endswith("MW"):
+            return int(float(value[:-2]) * 1000)
+        if value.endswith("W"):
+            return int(float(value[:-1]) / 1000)
+        raise ValueError(f"Unknown power unit in {value}")
+
+    def load(self) -> None:
+        from core.enums.assembling_machine import AssemblingMachine
+
+        entities = self.load_json(
+            f"{self.intermediate_dir}/{self.json_entities_filename}"
+        )
+        drills = self.load_json(
+            f"{self.intermediate_dir}/{self.json_mining_drill_filename}"
+        )
+
+        records: dict[str, tuple[float, int, int]] = {}
+        for e in entities:
+            if e.get("type") in {
+                "assembling-machine",
+                "lab",
+                "furnace",
+                "chemical-plant",
+                "oil-refinery",
+                "offshore-pump",
+                "rocket-silo",
+                "centrifuge",
+            }:
+                name = e["name"]
+                speed = float(e.get("crafting_speed", 0))
+                energy = e.get("energy_usage", "0kW")
+                slots = e.get("module_slots", 0) or 0
+                records[name] = (speed, self._parse_power_kw(energy), int(slots))
+
+        for d in drills:
+            name = d["name"]
+            speed = float(d.get("mining_speed", 0))
+            energy = d.get("energy_usage", "0kW")
+            slots = d.get("module_slots", 0) or 0
+            records[name] = (speed, self._parse_power_kw(energy), int(slots))
+
+        crafting_speed: dict[AssemblingMachine, Rational] = {}
+        energy_usage: dict[AssemblingMachine, Integer] = {}
+        module_slots: dict[AssemblingMachine, Integer] = {}
+
+        for name, (speed, energy_kw, slots) in records.items():
+            enum = AssemblingMachine(name)
+            crafting_speed[enum] = Rational(speed).limit_denominator(100)
+            energy_usage[enum] = Integer(energy_kw)
+            module_slots[enum] = Integer(slots)
+
+        out = [
+            "from sympy import Integer, Rational",
+            "from core.enums.assembling_machine import AssemblingMachine",
+            "",
+            "CRAFTING_SPEED: dict[AssemblingMachine, Rational] = {",
+            *[f"    {m}: {srepr(speed)}," for m, speed in crafting_speed.items()],
+            "}",
+            "",
+            "ENERGY_USAGE_KW: dict[AssemblingMachine, Integer] = {",
+            *[f"    {m}: {srepr(power)}," for m, power in energy_usage.items()],
+            "}",
+            "",
+            "MODULE_SLOTS: dict[AssemblingMachine, Integer] = {",
+            *[f"    {m}: {srepr(slots)}," for m, slots in module_slots.items()],
+            "}",
+        ]
+        (Path(self.data_dir) / self.data_path).write_text("\n".join(out))

--- a/core/loader/converters/model/data/mining_drill.py
+++ b/core/loader/converters/model/data/mining_drill.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from sympy import Integer, Rational, srepr
+
+from core.loader.converters.base import BaseConverter
+from core.loader.registry import register
+
+
+@register("data:mining_drill")
+class MiningDrillDataConverter(BaseConverter):
+    """Convert mining drill JSON to data dictionaries."""
+
+    dependencies = ["json:mining_drill", "enum:assembling_machine"]
+    json_filename = "mining_drill.json"
+    data_path = "mining_drill.py"
+
+    def _parse_power_kw(self, value: str) -> int:
+        if value.endswith("kW"):
+            return int(float(value[:-2]))
+        if value.endswith("MW"):
+            return int(float(value[:-2]) * 1000)
+        if value.endswith("W"):
+            return int(float(value[:-1]) / 1000)
+        raise ValueError(f"Unknown power unit in {value}")
+
+    def load(self) -> None:
+        from core.enums.assembling_machine import AssemblingMachine
+
+        drills = self.load_json(f"{self.intermediate_dir}/{self.json_filename}")
+
+        speed: dict[AssemblingMachine, Rational] = {}
+        energy: dict[AssemblingMachine, Integer] = {}
+        slots: dict[AssemblingMachine, Integer] = {}
+
+        for d in drills:
+            enum = AssemblingMachine(d["name"])
+            spd = Rational(float(d.get("mining_speed", 0))).limit_denominator(100)
+            power = Integer(self._parse_power_kw(d.get("energy_usage", "0kW")))
+            slot = Integer(d.get("module_slots", 0) or 0)
+            speed[enum] = spd
+            energy[enum] = power
+            slots[enum] = slot
+
+        out = [
+            "from sympy import Integer, Rational",
+            "from core.enums.assembling_machine import AssemblingMachine",
+            "",
+            "MINING_SPEED: dict[AssemblingMachine, Rational] = {",
+            *[f"    {m}: {srepr(v)}," for m, v in speed.items()],
+            "}",
+            "",
+            "ENERGY_USAGE_KW: dict[AssemblingMachine, Integer] = {",
+            *[f"    {m}: {srepr(v)}," for m, v in energy.items()],
+            "}",
+            "",
+            "MODULE_SLOTS: dict[AssemblingMachine, Integer] = {",
+            *[f"    {m}: {srepr(v)}," for m, v in slots.items()],
+            "}",
+        ]
+        (Path(self.data_dir) / self.data_path).write_text("\n".join(out))

--- a/core/models/allowed/mining_drill.py
+++ b/core/models/allowed/mining_drill.py
@@ -1,0 +1,7 @@
+from core.enums.assembling_machine import AssemblingMachine
+
+mining_drill_allowed: set[AssemblingMachine] = {
+    AssemblingMachine.ElectricMiningDrill,
+    AssemblingMachine.BurnerMiningDrill,
+    AssemblingMachine.Pumpjack,
+}

--- a/core/models/data/assembling_machine.py
+++ b/core/models/data/assembling_machine.py
@@ -1,0 +1,57 @@
+from sympy import Integer, Rational
+
+from core.enums.assembling_machine import AssemblingMachine
+
+CRAFTING_SPEED: dict[AssemblingMachine, Rational] = {
+    AssemblingMachine.StoneFurnace: Integer(1),
+    AssemblingMachine.OffshorePump: Integer(0),
+    AssemblingMachine.AssemblingMachine1: Rational(1, 2),
+    AssemblingMachine.AssemblingMachine2: Rational(3, 4),
+    AssemblingMachine.Lab: Integer(0),
+    AssemblingMachine.ElectricFurnace: Integer(2),
+    AssemblingMachine.SteelFurnace: Integer(2),
+    AssemblingMachine.AssemblingMachine3: Rational(5, 4),
+    AssemblingMachine.RocketSilo: Integer(1),
+    AssemblingMachine.OilRefinery: Integer(1),
+    AssemblingMachine.ChemicalPlant: Integer(1),
+    AssemblingMachine.Centrifuge: Integer(1),
+    AssemblingMachine.ElectricMiningDrill: Rational(1, 2),
+    AssemblingMachine.BurnerMiningDrill: Rational(1, 4),
+    AssemblingMachine.Pumpjack: Integer(1),
+}
+
+ENERGY_USAGE_KW: dict[AssemblingMachine, Integer] = {
+    AssemblingMachine.StoneFurnace: Integer(90),
+    AssemblingMachine.OffshorePump: Integer(60),
+    AssemblingMachine.AssemblingMachine1: Integer(75),
+    AssemblingMachine.AssemblingMachine2: Integer(150),
+    AssemblingMachine.Lab: Integer(60),
+    AssemblingMachine.ElectricFurnace: Integer(180),
+    AssemblingMachine.SteelFurnace: Integer(90),
+    AssemblingMachine.AssemblingMachine3: Integer(375),
+    AssemblingMachine.RocketSilo: Integer(250),
+    AssemblingMachine.OilRefinery: Integer(420),
+    AssemblingMachine.ChemicalPlant: Integer(210),
+    AssemblingMachine.Centrifuge: Integer(350),
+    AssemblingMachine.ElectricMiningDrill: Integer(90),
+    AssemblingMachine.BurnerMiningDrill: Integer(150),
+    AssemblingMachine.Pumpjack: Integer(90),
+}
+
+MODULE_SLOTS: dict[AssemblingMachine, Integer] = {
+    AssemblingMachine.StoneFurnace: Integer(0),
+    AssemblingMachine.OffshorePump: Integer(0),
+    AssemblingMachine.AssemblingMachine1: Integer(0),
+    AssemblingMachine.AssemblingMachine2: Integer(2),
+    AssemblingMachine.Lab: Integer(2),
+    AssemblingMachine.ElectricFurnace: Integer(2),
+    AssemblingMachine.SteelFurnace: Integer(0),
+    AssemblingMachine.AssemblingMachine3: Integer(4),
+    AssemblingMachine.RocketSilo: Integer(4),
+    AssemblingMachine.OilRefinery: Integer(3),
+    AssemblingMachine.ChemicalPlant: Integer(3),
+    AssemblingMachine.Centrifuge: Integer(2),
+    AssemblingMachine.ElectricMiningDrill: Integer(3),
+    AssemblingMachine.BurnerMiningDrill: Integer(0),
+    AssemblingMachine.Pumpjack: Integer(2),
+}

--- a/core/models/data/mining_drill.py
+++ b/core/models/data/mining_drill.py
@@ -1,0 +1,21 @@
+from sympy import Integer, Rational
+
+from core.enums.assembling_machine import AssemblingMachine
+
+MINING_SPEED: dict[AssemblingMachine, Rational] = {
+    AssemblingMachine.ElectricMiningDrill: Rational(1, 2),
+    AssemblingMachine.BurnerMiningDrill: Rational(1, 4),
+    AssemblingMachine.Pumpjack: Integer(1),
+}
+
+ENERGY_USAGE_KW: dict[AssemblingMachine, Integer] = {
+    AssemblingMachine.ElectricMiningDrill: Integer(90),
+    AssemblingMachine.BurnerMiningDrill: Integer(150),
+    AssemblingMachine.Pumpjack: Integer(90),
+}
+
+MODULE_SLOTS: dict[AssemblingMachine, Integer] = {
+    AssemblingMachine.ElectricMiningDrill: Integer(3),
+    AssemblingMachine.BurnerMiningDrill: Integer(0),
+    AssemblingMachine.Pumpjack: Integer(2),
+}


### PR DESCRIPTION
## Summary
- implement data converters for assembling machines and mining drills
- add allowed list converter for mining drills
- generate data modules for machine stats

## Testing
- `bash scripts/format.sh`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856cafad5648329870684a77e1ede97